### PR TITLE
bandaid fix for some of the weird crashes on officials 

### DIFF
--- a/src/main/java/vswe/stevesfactory/SFMLogging.java
+++ b/src/main/java/vswe/stevesfactory/SFMLogging.java
@@ -1,0 +1,26 @@
+package vswe.stevesfactory;
+
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.util.ChatComponentTranslation;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.FormattedMessageFactory;
+import org.apache.logging.log4j.message.Message;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.apache.logging.log4j.message.ParameterizedMessageFactory;
+import org.lwjgl.Sys;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+public class SFMLogging {
+    public static final Logger LOGGER = LogManager.getLogger("SteveFactoryManager");
+
+    public static void reportIncident(Exception ex, String location, Iterable<EntityPlayerMP> receivers) {
+        String incidentId = "" + System.currentTimeMillis() + ThreadLocalRandom.current().nextInt(1000);
+        Message message = new ParameterizedMessage("Exception in {}. Incident ID {}.", new Object[] {location, incidentId}, ex);
+        LOGGER.error(message);
+        for (EntityPlayerMP player : receivers) {
+            player.addChatMessage(new ChatComponentTranslation("chat.sfm.ContainerInternalServerError", incidentId));
+        }
+    }
+}

--- a/src/main/java/vswe/stevesfactory/interfaces/ContainerManager.java
+++ b/src/main/java/vswe/stevesfactory/interfaces/ContainerManager.java
@@ -34,7 +34,7 @@ public class ContainerManager extends ContainerBase {
     @Override
     public void detectAndSendChanges() {
         try {
-            detectAndSendChanges0();
+            detectAndSendChangesImpl();
         } catch (Exception e) {
             SFMLogging.reportIncident(e, "ContainerManager#detectAndSendChanges", Iterables.filter(getCrafters(), EntityPlayerMP.class));
             for (ICrafting crafter : getCrafters()) {
@@ -45,7 +45,7 @@ public class ContainerManager extends ContainerBase {
         }
     }
 
-    private void detectAndSendChanges0() {
+    private void detectAndSendChangesImpl() {
         super.detectAndSendChanges();
 
         if (oldComponents != null) {

--- a/src/main/java/vswe/stevesfactory/interfaces/ContainerManager.java
+++ b/src/main/java/vswe/stevesfactory/interfaces/ContainerManager.java
@@ -1,9 +1,12 @@
 package vswe.stevesfactory.interfaces;
 
+import com.google.common.collect.Iterables;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.ICrafting;
 import net.minecraft.tileentity.TileEntity;
+import vswe.stevesfactory.SFMLogging;
 import vswe.stevesfactory.blocks.ConnectionBlock;
 import vswe.stevesfactory.blocks.TileEntityManager;
 import vswe.stevesfactory.blocks.WorldCoordinate;
@@ -30,6 +33,19 @@ public class ContainerManager extends ContainerBase {
 
     @Override
     public void detectAndSendChanges() {
+        try {
+            detectAndSendChanges0();
+        } catch (Exception e) {
+            SFMLogging.reportIncident(e, "ContainerManager#detectAndSendChanges", Iterables.filter(getCrafters(), EntityPlayerMP.class));
+            for (ICrafting crafter : getCrafters()) {
+                if (crafter instanceof EntityPlayerMP) {
+                    ((EntityPlayerMP) crafter).closeScreen();
+                }
+            }
+        }
+    }
+
+    private void detectAndSendChanges0() {
         super.detectAndSendChanges();
 
         if (oldComponents != null) {

--- a/src/main/resources/assets/stevesfactory/lang/en_US.lang
+++ b/src/main/resources/assets/stevesfactory/lang/en_US.lang
@@ -405,3 +405,5 @@ gui.sfm.PermissionDenied=No access
 # ======================================
 
 itemGroup.sfm=Steve's Factory Manager
+
+chat.sfm.ContainerInternalServerError=Unknown Internal Server Error occurred. We have closed the container for your safety. More info in server logs. Incident ID "%s".


### PR DESCRIPTION
Make the server not crash when something like this happens: https://discord.com/channels/181078474394566657/240526986211098624/968168772743598093 Instead the GUI will be closed with a message saying something went wrong. Let's hope closing it will not leave the container in a broken state...

**Does not** prevent all sfm related crashes.