### PR TITLE
Fix crash when component name contains non ASCII/Latin-1 characters

### DIFF
--- a/src/main/java/vswe/stevesfactory/components/TextBoxLogic.java
+++ b/src/main/java/vswe/stevesfactory/components/TextBoxLogic.java
@@ -84,7 +84,7 @@ public class TextBoxLogic {
             deleteText(gui, 1);
         } else if (c == 22 && k == 47/* ctrl v */) {
             addText(gui, GuiScreen.getClipboardString());
-        } else if (c != 0 && Character.isDefined(c)) {
+        } else if (c != 0 && (Character.isDefined(c) && !Character.isISOControl(c))) {
             addText(gui, Character.toString(c));
         }
     }

--- a/src/main/java/vswe/stevesfactory/components/TextBoxLogic.java
+++ b/src/main/java/vswe/stevesfactory/components/TextBoxLogic.java
@@ -1,6 +1,6 @@
 package vswe.stevesfactory.components;
 
-import net.minecraft.util.ChatAllowedCharacters;
+import net.minecraft.client.gui.GuiScreen;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -74,6 +74,8 @@ public class TextBoxLogic {
 
     @SideOnly(Side.CLIENT)
     public void onKeyStroke(GuiManager gui, char c, int k) {
+        System.out.println((c + 0) + " " + k);
+
         if (k == 203) {
             moveCursor(gui, -1);
         } else if (k == 205) {
@@ -82,8 +84,10 @@ public class TextBoxLogic {
             deleteText(gui, -1);
         } else if (k == 211) {
             deleteText(gui, 1);
-        } else if (ChatAllowedCharacters.isAllowedCharacter(c)) {
+        } else if (k == 0 && Character.isDefined(c)) {
             addText(gui, Character.toString(c));
+        } else if (c == 22 && k == 47/* ctrl v */) {
+            addText(gui, GuiScreen.getClipboardString());
         }
     }
 

--- a/src/main/java/vswe/stevesfactory/components/TextBoxLogic.java
+++ b/src/main/java/vswe/stevesfactory/components/TextBoxLogic.java
@@ -74,8 +74,6 @@ public class TextBoxLogic {
 
     @SideOnly(Side.CLIENT)
     public void onKeyStroke(GuiManager gui, char c, int k) {
-        System.out.println((c + 0) + " " + k);
-
         if (k == 203) {
             moveCursor(gui, -1);
         } else if (k == 205) {
@@ -84,10 +82,10 @@ public class TextBoxLogic {
             deleteText(gui, -1);
         } else if (k == 211) {
             deleteText(gui, 1);
-        } else if (k == 0 && Character.isDefined(c)) {
-            addText(gui, Character.toString(c));
         } else if (c == 22 && k == 47/* ctrl v */) {
             addText(gui, GuiScreen.getClipboardString());
+        } else if (c != 0 && Character.isDefined(c)) {
+            addText(gui, Character.toString(c));
         }
     }
 

--- a/src/main/java/vswe/stevesfactory/network/DataWriter.java
+++ b/src/main/java/vswe/stevesfactory/network/DataWriter.java
@@ -107,7 +107,7 @@ public class DataWriter {
         if (str != null) {
             byte[] bytes = str.getBytes();
             writeData(bytes.length, bits);
-            int l = str.length() & ((int) Math.pow(2, bits.getBitCount()) - 1);
+            int l = bytes.length & ((int) Math.pow(2, bits.getBitCount()) - 1);
 
             for (int i = 0; i < l; i++) {
                 writeByte(bytes[i]);


### PR DESCRIPTION
Before PR you will get this when you rename components with Chinese characters.

```
java.lang.ArrayIndexOutOfBoundsException: 7
	at vswe.stevesfactory.components.ItemSetting.readData(ItemSetting.java:101) ~[ItemSetting.class:?]
	at vswe.stevesfactory.components.ComponentMenuStuff.readData(ComponentMenuStuff.java:401) ~[ComponentMenuStuff.class:?]
	at vswe.stevesfactory.blocks.TileEntityManager.readAllComponentData(TileEntityManager.java:599) ~[TileEntityManager.class:?]
	at vswe.stevesfactory.blocks.TileEntityManager.readAllData(TileEntityManager.java:557) ~[TileEntityManager.class:?]
	at vswe.stevesfactory.network.PacketEventHandler.onClientPacket(PacketEventHandler.java:33) ~[PacketEventHandler.class:?]
	at cpw.mods.fml.common.eventhandler.ASMEventHandler_1976_PacketEventHandler_onClientPacket_ClientCustomPacketEvent.invoke(.dynamic) ~[?:?]
	at cpw.mods.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:54) ~[ASMEventHandler.class:?]
	at cpw.mods.fml.common.eventhandler.EventBus.post(EventBus.java:140) ~[EventBus.class:?]
	at cpw.mods.fml.common.network.FMLEventChannel.fireRead(FMLEventChannel.java:103) ~[FMLEventChannel.class:?]
	at cpw.mods.fml.common.network.NetworkEventFiringHandler.channelRead0(NetworkEventFiringHandler.java:30) ~[NetworkEventFiringHandler.class:?]
	at cpw.mods.fml.common.network.NetworkEventFiringHandler.channelRead0(NetworkEventFiringHandler.java:18) ~[NetworkEventFiringHandler.class:?]
	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:98) ~[netty-all-4.0.10.Final.jar:?]
	at io.netty.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:337) ~[netty-all-4.0.10.Final.jar:?]
	at io.netty.channel.DefaultChannelHandlerContext.fireChannelRead(DefaultChannelHandlerContext.java:323) ~[netty-all-4.0.10.Final.jar:?]
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:785) ~[netty-all-4.0.10.Final.jar:?]
	at io.netty.channel.embedded.EmbeddedChannel.writeInbound(EmbeddedChannel.java:169) ~[netty-all-4.0.10.Final.jar:?]
	at cpw.mods.fml.common.network.internal.FMLProxyPacket.func_148833_a(FMLProxyPacket.java:77) [FMLProxyPacket.class:?]
	at net.minecraft.network.NetworkManager.func_74428_b(NetworkManager.java:212) [ej.class:?]
	at net.minecraft.client.multiplayer.PlayerControllerMP.func_78765_e(PlayerControllerMP.java:273) [bje.class:?]
	at net.minecraft.client.Minecraft.func_71407_l(Minecraft.java:1602) [bao.class:?]
	at net.minecraft.client.Minecraft.func_71411_J(Minecraft.java:973) [bao.class:?]
	at net.minecraft.client.Minecraft.func_99999_d(Minecraft.java:4610) [bao.class:?]
	at net.minecraft.client.main.Main.main(SourceFile:148) [Main.class:?]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_432-432]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_432-432]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_432-432]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_432-432]
	at net.minecraft.launchwrapper.Launch.launch(Launch.java:135) [launchwrapper-1.12.jar:?]
	at net.minecraft.launchwrapper.Launch.main(Launch.java:28) [launchwrapper-1.12.jar:?]
```
Now it won't crash.
<img width="1036" alt="1743753458309" src="https://github.com/user-attachments/assets/24a12981-8989-453e-9c03-e7cde4ef7570" />



Also add ctrl-v clipboard paste support to textbox.

ctrl-x & ctrl-c is not possible, since SFM textbox do not support text select 


