### PR TITLE
Added Optional command title localization

### DIFF
--- a/src/main/java/vswe/stevesfactory/Localization.java
+++ b/src/main/java/vswe/stevesfactory/Localization.java
@@ -38,6 +38,7 @@ public enum Localization {
     CAMOUFLAGE_LONG,
     SIGN_SHORT,
     SIGN_LONG,
+    COMMAND_NAME_FORMAT,
 
     CONNECTION_INPUT,
     CONNECTION_OUTPUT,

--- a/src/main/java/vswe/stevesfactory/components/FlowComponent.java
+++ b/src/main/java/vswe/stevesfactory/components/FlowComponent.java
@@ -16,6 +16,8 @@ import org.lwjgl.opengl.GL11;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import vswe.stevesfactory.CollisionHelper;
+import vswe.stevesfactory.Localization;
+import vswe.stevesfactory.StevesFactoryManager;
 import vswe.stevesfactory.blocks.TileEntityManager;
 import vswe.stevesfactory.interfaces.ContainerManager;
 import vswe.stevesfactory.interfaces.GuiManager;
@@ -409,10 +411,7 @@ public class FlowComponent implements IComponentNetworkReader, Comparable<FlowCo
         }
 
         if (!isEditing || isLarge) {
-            String name = getName();
-            if (!isLarge) {
-                name = getShortName(gui, name);
-            }
+            String name = getDisplayName(gui, !isLarge);
             gui.drawString(name, x + TEXT_X, y + TEXT_Y, 0.7F, isEditing ? 0x707020 : 0x404040);
         }
 
@@ -474,6 +473,44 @@ public class FlowComponent implements IComponentNetworkReader, Comparable<FlowCo
 
     private String cachedName;
     private String cachedShortName;
+
+    private String getDisplayName(GuiManager gui, boolean shorten) {
+        String displayName = getName();
+        if (textBox.getText() == null) {
+            if (name == null || GuiScreen.isCtrlKeyDown()) {
+                // Apply a resource-pack format to the default component name for better contrast.
+                displayName = formatDefaultName(displayName);
+            } else if (!hasColorCode(name)) {
+                // Keep custom names readable by formatting when no explicit color codes are used.
+                displayName = formatDefaultName(displayName);
+            }
+        }
+        if (shorten) {
+            displayName = getShortName(gui, displayName);
+        }
+        return displayName;
+    }
+
+    private boolean hasColorCode(String value) {
+        return value != null && value.indexOf('\u00A7') >= 0;
+    }
+
+    private String formatDefaultName(String defaultName) {
+        String format = Localization.COMMAND_NAME_FORMAT.toString();
+        // Only format when the localization key exists and uses a "%s" placeholder.
+        if (isValidFormat(format)) {
+            return format.replace("%s", defaultName);
+        }
+        return defaultName;
+    }
+
+    private boolean isValidFormat(String format) {
+        // Missing keys resolve to the key string itself; treat that as "no format".
+        if (format == null || !format.contains("%s")) {
+            return false;
+        }
+        return !format.equals("gui." + StevesFactoryManager.UNLOCALIZED_START + "CommandNameFormat");
+    }
 
     private String getShortName(GuiManager gui, String name) {
         if (!name.equals(cachedName)) {


### PR DESCRIPTION
Given the resource pack makers the ability to change the default fallback command title color. For normal user nothing will change.

Now there is ability to add:
`gui.sfm.CommandNameFormat=§6%s` (example orange)
inside the resource pack, that will override the custom set command title.

| Before | After |
| - | - |
| <img width="192" height="78" alt="Before" src="https://github.com/user-attachments/assets/6549ed33-5185-43bb-9f60-30455323e1a2" />|  <img width="192" height="78" alt="After" src="https://github.com/user-attachments/assets/784d1d58-e303-4111-b22a-96195af201ad" />|

