### PR TITLE
Fix timer counting in Machine Inventory Manager

### DIFF
--- a/src/main/java/vswe/stevesfactory/blocks/TileEntityManager.java
+++ b/src/main/java/vswe/stevesfactory/blocks/TileEntityManager.java
@@ -439,6 +439,7 @@ public class TileEntityManager extends TileEntity implements ITileEntityInterfac
 
             if (HAS_ADDONS) ADDONS_HOOKS.tickTriggers(this);
 
+            timer++;
             if (timer >= 20) {
                 timer = 0;
 
@@ -465,9 +466,6 @@ public class TileEntityManager extends TileEntity implements ITileEntityInterfac
                         }
                     }
                 }
-
-            } else {
-                timer++;
             }
         }
     }


### PR DESCRIPTION
Fixes the Timer Counting to count 1 second as 20 Ticks, not 21.
tested in full pack, works as intended now. Did the same comparison with 2 other 1-second timers as in the ticket, no desync anymore.
I'm not 100% sure if this has any edge cases where it breaks now, but im 99% sure.
should fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/23275