### PR TITLE
Change fake player UUID to be non-null

### DIFF
--- a/src/main/java/vswe/stevesfactory/blocks/TileEntityBreaker.java
+++ b/src/main/java/vswe/stevesfactory/blocks/TileEntityBreaker.java
@@ -1,5 +1,6 @@
 package vswe.stevesfactory.blocks;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
@@ -32,7 +33,8 @@ import vswe.stevesfactory.network.PacketHandler;
 public class TileEntityBreaker extends TileEntityClusterElement implements IInventory, IPacketBlock {
 
     private static final String FAKE_PLAYER_NAME = "[SFM_PLAYER]";
-    private static final UUID FAKE_PLAYER_ID = null;
+    private static final UUID FAKE_PLAYER_ID = UUID
+            .nameUUIDFromBytes(FAKE_PLAYER_NAME.getBytes(StandardCharsets.UTF_8));
     private List<ItemStack> inventory;
     private List<ItemStack> inventoryCache;
     private boolean broken;


### PR DESCRIPTION
This fixes a null pointer exception in ServerUtilities claims which allows SFM block gates to place blocks in claimed chunks.

```
java.lang.NullPointerException: Cannot invoke "java.util.UUID.toString()" because the return value of "com.mojang.authlib.GameProfile.getId()" is null
	at Launch//net.minecraft.server.management.UserListOps.func_152699_b(SourceFile:39) ~[oj.class:?]
	at Launch//net.minecraft.server.management.UserListOps.func_152681_a(SourceFile:9) ~[oj.class:?]
	at Launch//net.minecraft.server.management.UserList.func_152692_d(SourceFile:85) ~[om.class:?]
	at Launch//net.minecraft.server.management.ServerConfigurationManager.func_152596_g(ServerConfigurationManager.java:717) ~[oi.class:?]
	at Launch//serverutils.lib.util.permission.DefaultPermissionHandler.hasPermission(DefaultPermissionHandler.java:54) ~[DefaultPermissionHandler.class:?]
	at Launch//serverutils.lib.util.permission.PermissionAPI.hasPermission(PermissionAPI.java:67) ~[PermissionAPI.class:?]
	at Launch//serverutils.lib.util.permission.PermissionAPI.hasPermission(PermissionAPI.java:77) ~[PermissionAPI.class:?]
	at Launch//serverutils.ServerUtilitiesPermissions.hasBlockInteractionPermission(ServerUtilitiesPermissions.java:397) ~[ServerUtilitiesPermissions.class:?]
	at Launch//serverutils.data.ClaimedChunks.blockBlockInteractions(ClaimedChunks.java:264) ~[ClaimedChunks.class:?]
	at Launch//serverutils.handlers.ServerUtilitiesPlayerEventHandler.onPlayerInteraction(ServerUtilitiesPlayerEventHandler.java:199) ~[ServerUtilitiesPlayerEventHandler.class:?]
	at com.gtnewhorizon.gtnhlib.eventbus.StaticASMEventHandler_14_ServerUtilitiesPlayerEventHandler_onPlayerInteraction_PlayerInteractEvent.invoke(.dynamic) ~[?:?]
	at Launch//com.gtnewhorizon.gtnhlib.eventbus.StaticASMEventHandler.invoke(StaticASMEventHandler.java:39) ~[StaticASMEventHandler.class:?]
	at Launch//cpw.mods.fml.common.eventhandler.EventBus.post(EventBus.java:140) [EventBus.class:?]
	at Launch//net.minecraftforge.event.ForgeEventFactory.onPlayerInteract(ForgeEventFactory.java:100) [ForgeEventFactory.class:?]
	at Launch//net.minecraft.server.management.ItemInWorldManager.func_73078_a(ItemInWorldManager.java:353) [mx.class:?]
	at Launch//vswe.stevesfactory.blocks.TileEntityBreaker.placeItem(TileEntityBreaker.java:103) [TileEntityBreaker.class:?]
	at Launch//vswe.stevesfactory.blocks.TileEntityBreaker.func_145845_h(TileEntityBreaker.java:149) [TileEntityBreaker.class:?]
	at Launch//net.minecraft.world.World.func_72939_s(World.java:1939) [ahb.class:?]
	at Launch//net.minecraft.world.WorldServer.func_72939_s(WorldServer.java:489) [mt.class:?]
	at Launch//net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:636) [MinecraftServer.class:?]
	at Launch//net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:334) [lt.class:?]
	at Launch//net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:547) [MinecraftServer.class:?]
	at Launch//net.minecraft.server.MinecraftServer.run(MinecraftServer.java:427) [MinecraftServer.class:?]
	at Launch//net.minecraft.server.MinecraftServer$2.run(MinecraftServer.java:685) [li.class:?]
```