### PR TITLE
Fix block breaker causing Block.breakBlock to be called twice

### DIFF
--- a/src/main/java/vswe/stevesfactory/blocks/TileEntityBreaker.java
+++ b/src/main/java/vswe/stevesfactory/blocks/TileEntityBreaker.java
@@ -332,7 +332,6 @@ public class TileEntityBreaker extends TileEntityClusterElement implements IInve
                 if (canBreakBlock(block, x, y, z)) {
                     broken = true;
                     int meta = worldObj.getBlockMetadata(x, y, z);
-                    block.breakBlock(worldObj, x, y, z, block, meta);
                     worldObj.playAuxSFX(2001, x, y, z, Block.getIdFromBlock(block) + (meta << 12));
                     worldObj.setBlockToAir(x, y, z);
                 }


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24548

`worldObj.setBlockToAir(x, y, z);` later already calls `Block.breakBlock`, so this is superfluous.

Since `breakBlock` removes the tile entity, and FloodLights expects the TileEntity to be available, this will crash on the duplicate call.